### PR TITLE
3.x branch - Update PHP 7.2 cli and Terminus Build Tools 2.0.0-beta1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM drupaldocker/php:7.1-cli
+FROM drupaldocker/php:7.2-cli
 
 # Set the working directory to /build-tools-ci
 WORKDIR /build-tools-ci
@@ -30,7 +30,7 @@ RUN chmod +x /usr/local/bin/drush
 # Add a collection of useful Terminus plugins
 env TERMINUS_PLUGINS_DIR /usr/local/share/terminus-plugins
 RUN mkdir -p /usr/local/share/terminus-plugins
-RUN composer -n create-project -d /usr/local/share/terminus-plugins pantheon-systems/terminus-build-tools-plugin:^2.0.0-alpha5
+RUN composer -n create-project -d /usr/local/share/terminus-plugins pantheon-systems/terminus-build-tools-plugin:^2.0.0-beta1
 RUN composer -n create-project -d /usr/local/share/terminus-plugins pantheon-systems/terminus-secrets-plugin:^1
 RUN composer -n create-project -d /usr/local/share/terminus-plugins pantheon-systems/terminus-rsync-plugin:^1
 RUN composer -n create-project -d /usr/local/share/terminus-plugins pantheon-systems/terminus-quicksilver-plugin:^1


### PR DESCRIPTION
Update Docker image to PHP 7.2 cli. Update Terminus Build Tools to 2.0.0-beta1