### PR TITLE
Update CLU to 0.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN /usr/bin/env COMPOSER_BIN_DIR=/usr/local/bin composer -n --working-dir=/usr/
 
 # Install CLU
 RUN mkdir -p /usr/local/share/clu
-RUN /usr/bin/env COMPOSER_BIN_DIR=/usr/local/bin composer -n --working-dir=/usr/local/share/clu require danielbachhuber/composer-lock-updater:^0.6.3
+RUN /usr/bin/env COMPOSER_BIN_DIR=/usr/local/bin composer -n --working-dir=/usr/local/share/clu require danielbachhuber/composer-lock-updater:^0.6.4
 
 # Install Drush
 RUN mkdir -p /usr/local/share/drush

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN /usr/bin/env COMPOSER_BIN_DIR=/usr/local/bin composer -n --working-dir=/usr/
 
 # Install CLU
 RUN mkdir -p /usr/local/share/clu
-RUN /usr/bin/env COMPOSER_BIN_DIR=/usr/local/bin composer -n --working-dir=/usr/local/share/clu require danielbachhuber/composer-lock-updater:^0.6.2
+RUN /usr/bin/env COMPOSER_BIN_DIR=/usr/local/bin composer -n --working-dir=/usr/local/share/clu require danielbachhuber/composer-lock-updater:^0.6.3
 
 # Install Drush
 RUN mkdir -p /usr/local/share/drush

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN /usr/bin/env COMPOSER_BIN_DIR=/usr/local/bin composer -n --working-dir=/usr/
 
 # Install CLU
 RUN mkdir -p /usr/local/share/clu
-RUN /usr/bin/env COMPOSER_BIN_DIR=/usr/local/bin composer -n --working-dir=/usr/local/share/clu require danielbachhuber/composer-lock-updater:^0.6.1
+RUN /usr/bin/env COMPOSER_BIN_DIR=/usr/local/bin composer -n --working-dir=/usr/local/share/clu require danielbachhuber/composer-lock-updater:^0.6.2
 
 # Install Drush
 RUN mkdir -p /usr/local/share/drush

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ RUN docker-php-ext-configure sodium
 RUN docker-php-ext-install sodium
 RUN pecl install libsodium-2.0.21
 
-
+# Set the memory limit to unlimited for expensive Composer interactions
+RUN echo "memory_limit=-1" > /usr/local/etc/php/conf.d/memory.ini
 
 ###########################
 # Install build tools things

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN /usr/bin/env COMPOSER_BIN_DIR=/usr/local/bin composer -n --working-dir=/usr/
 
 # Install CLU
 RUN mkdir -p /usr/local/share/clu
-RUN /usr/bin/env COMPOSER_BIN_DIR=/usr/local/bin composer -n --working-dir=/usr/local/share/clu require danielbachhuber/composer-lock-updater:^0.6.0
+RUN /usr/bin/env COMPOSER_BIN_DIR=/usr/local/bin composer -n --working-dir=/usr/local/share/clu require danielbachhuber/composer-lock-updater:^0.6.1
 
 # Install Drush
 RUN mkdir -p /usr/local/share/drush

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN /usr/bin/env COMPOSER_BIN_DIR=/usr/local/bin composer -n --working-dir=/usr/
 
 # Install CLU
 RUN mkdir -p /usr/local/share/clu
-RUN /usr/bin/env COMPOSER_BIN_DIR=/usr/local/bin composer -n --working-dir=/usr/local/share/clu require danielbachhuber/composer-lock-updater:^0.6.4
+RUN /usr/bin/env COMPOSER_BIN_DIR=/usr/local/bin composer -n --working-dir=/usr/local/share/clu require danielbachhuber/composer-lock-updater:^0.7.0
 
 # Install Drush
 RUN mkdir -p /usr/local/share/drush

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN /usr/bin/env COMPOSER_BIN_DIR=/usr/local/bin composer -n --working-dir=/usr/
 
 # Install CLU
 RUN mkdir -p /usr/local/share/clu
-RUN /usr/bin/env COMPOSER_BIN_DIR=/usr/local/bin composer -n --working-dir=/usr/local/share/clu require danielbachhuber/composer-lock-updater:^0.5.0
+RUN /usr/bin/env COMPOSER_BIN_DIR=/usr/local/bin composer -n --working-dir=/usr/local/share/clu require danielbachhuber/composer-lock-updater:^0.6.0
 
 # Install Drush
 RUN mkdir -p /usr/local/share/drush


### PR DESCRIPTION
- Adds support for GitLab repositories.
- Changes behavior to close existing PR and open a new one when existing PR dependencies are outdated.