### PR TITLE
Set PHP memory limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ RUN docker-php-ext-configure sodium
 RUN docker-php-ext-install sodium
 RUN pecl install libsodium-2.0.21
 
-
+# Set the memory limit to unlimited for expensive Composer interactions
+RUN echo "memory_limit=-1" > /usr/local/etc/php/conf.d/memory.ini
 
 ###########################
 # Install build tools things


### PR DESCRIPTION
We more and more are pushing memory intensive scripts to run in this Docker image (for example, `composer update`. To make sure this continues to run smoothly, we should adjust the memory limit from its default to one that is a bit more friendly to these scripts.