### PR TITLE
Allow installing build tools dev-master

### DIFF
--- a/scripts/set-environment
+++ b/scripts/set-environment
@@ -112,7 +112,7 @@ git config --global user.name "CI Bot"
 git config --global core.fileMode false
 
 # Re-install the Terminus Build Tools plugin if requested
-if [ -n $BUILD_TOOLS_VERSION ] && [ "$BUILD_TOOLS_VERSION" <> 'dev-master' ]; then
+if [ -n $BUILD_TOOLS_VERSION ]; then
   echo "Install Terminus Build Tools Plugin version $BUILD_TOOLS_VERSION"
   rm -rf ${TERMINUS_PLUGINS_DIR:-~/.terminus/plugins}/terminus-build-tools-plugin
   composer -n create-project -d ${TERMINUS_PLUGINS_DIR:-~/.terminus/plugins} pantheon-systems/terminus-build-tools-plugin:$BUILD_TOOLS_VERSION


### PR DESCRIPTION
Is there a reason the set-environment script disallow installing dev-master version of build tools?
I would like to use it on 5.x