### PR TITLE
Add bitbucket terminus plugin to support composer lock updater

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,9 @@ RUN curl -LO https://github.com/github/hub/releases/download/v2.11.2/hub-linux-a
 # Add lab in case anyone wants to automate GitLab MR creation, etc.
 RUN curl -s https://raw.githubusercontent.com/zaquestion/lab/master/install.sh | bash
 
+# Add Terminus Bitbucket plugin in case anyone wants to automate Bitbucket PR creation, etc.
+RUN composer -n create-project --no-dev -d /usr/local/share/terminus-plugins aaronbauman/terminus-bitbucket-plugin:^2
+
 # Add phpcs for use in checking code style
 RUN mkdir ~/phpcs && cd ~/phpcs && COMPOSER_BIN_DIR=/usr/local/bin composer require squizlabs/php_codesniffer:^2.7
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This is the source Dockerfile for the [pantheon-public/build-tools-ci](https://q
   - [Terminus Drupal Console Plugin](https://github.com/pantheon-systems/terminus-drupal-console-plugin)
   - [Terminus Mass Update Plugin](https://github.com/pantheon-systems/terminus-mass-update)
   - [Terminus Aliases Plugin](https://github.com/pantheon-systems/terminus-aliases-plugin)
+  - [Terminus Bitbucket Plugin](https://github.com/aaronbauman/terminus-bitbucket-plugin)
 - Test tools
   - headless chrome
   - phpunit


### PR DESCRIPTION
Along with https://github.com/danielbachhuber/composer-lock-updater/pull/36, adding the rudimentary bitbucket-terminus plugin will allow scheduled clu jobs for Bitbucket

Feedback would be welcome, thanks