### PR TITLE
adding dnsutils to the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ USER root
 # Install necessary packages for PHP extensions
 RUN apt-get update && \
      apt-get install -y \
+        dnsutils \
         libzip-dev \
         libsodium-dev \
         libpng-dev \


### PR DESCRIPTION
Adds `dnstutils` to the container, see https://github.com/pantheon-systems/docker-build-tools-ci/issues/52.