### PR TITLE
Add imagick php extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ USER root
 RUN apt-get update && \
      apt-get install -y \
         dnsutils \
+        imagick \
         libzip-dev \
         libsodium-dev \
         libpng-dev \


### PR DESCRIPTION
The imagick php extension is used for generating images, such as a pdf thumbnail and is a dependency of many drupal modules.