### PR TITLE
Install SOAP extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && \
         libjpeg62-turbo-dev \
         zlib1g-dev \
         libicu-dev \
+        libxml2-dev \
         g++
 
 # Add necessary PHP Extensions
@@ -34,7 +35,7 @@ RUN docker-php-ext-enable imagick
 
 RUN docker-php-ext-install bcmath
 
-
+RUN docker-php-ext-install soap
 
 # Set the memory limit to unlimited for expensive Composer interactions
 RUN echo "memory_limit=-1" > /usr/local/etc/php/conf.d/memory.ini


### PR DESCRIPTION
Attempting to fix #69 

Added libxml2-dev as a dependency and added line 38 to install ext-soap. I'm not sure how to test whether this will actually work though, until the image is up in quay.io and we can attempt another CI build.

