### PR TITLE
[LOPS-1850] Add no longer maintained annotations and trigger image rebuild.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ FROM circleci/php:${PHPVERSION}-node-browsers
 # Switch to root user
 USER root
 
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
+
+
 # Install necessary packages for PHP extensions
 RUN apt-get update && \
      apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ This is the source Dockerfile for the [pantheon-public/build-tools-ci](https://q
 ## Branches
 
 - 7.x: Use a CircleCI base image with Node JS and composer 2. Produces 7.x-php7.3, 7.x-php7.4 and 7.x-php8.0 image tags.
-- 6.x: Use a CircleCI base image with Node JS
-- 5.x: Don't create multidevs when commits are made to the default branch, instead working directly on the dev environment
-- 4.x: Terminus 2.x and Build Tools 2.x
-- 3.x: Deprecated: Terminus 1 with Build Tools 2.0.0-beta2
-- 2.x: Terminus 1.x and Build Tools 1.x
-- 1.x: Deprecated
+- 6.x: Use a CircleCI base image with Node JS (No longer maintained)
+- 5.x: Don't create multidevs when commits are made to the default branch, instead working directly on the dev environment (No longer maintained)
+- 4.x: Terminus 2.x and Build Tools 2.x (No longer maintained)
+- 3.x: Deprecated: Terminus 1 with Build Tools 2.0.0-beta2 (No longer maintained)
+- 2.x: Terminus 1.x and Build Tools 1.x (No longer maintained)
+- 1.x: Deprecated (No longer maintained)
 
 ## 7.x Docker images
 


### PR DESCRIPTION
Before:

```
# dpkg -l | grep curl
ii  curl                                7.74.0-1.3+deb11u1             amd64        command line tool for transferring data with URL syntax
```

After:

```
# dpkg -l | grep curl
ii  curl                                7.74.0-1.3+deb11u10            amd64        command line tool for transferring data with URL syntax
```

It was patched in this version as per [CVE-2023-38545](https://security-tracker.debian.org/tracker/CVE-2023-38545)  and [CVE-2023-38546](https://security-tracker.debian.org/tracker/CVE-2023-38546)