### PR TITLE
Create 9.x branch for Terminus 4 upgrade

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -2,14 +2,14 @@ name: Docker Build Tools Image (Build and Push)
 on:
   push:
     branches:
-      - '8.x'
+      - '9.x'
 jobs:
   docker-build:
     runs-on: ubuntu-latest
     name: Build and push ${{ matrix.php-versions }} Docker image
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -35,7 +35,7 @@ jobs:
           context: .
           push: true
           tags: |
-            pantheonpublic/build-tools-ci:8.x-php${{ matrix.php-versions }}
-            quay.io/pantheon-public/build-tools-ci:8.x-php${{ matrix.php-versions }}
+            pantheonpublic/build-tools-ci:9.x-php${{ matrix.php-versions }}
+            quay.io/pantheon-public/build-tools-ci:9.x-php${{ matrix.php-versions }}
           build-args: |
             PHPVERSION=${{ matrix.php-versions }}

--- a/.github/workflows/build_only.yml
+++ b/.github/workflows/build_only.yml
@@ -2,15 +2,15 @@ name: Docker Build Tools Image (Build Only)
 on:
   push:
     branches-ignore:
-      - '7.x'
       - '8.x'
+      - '9.x'
 jobs:
   docker-build:
     runs-on: ubuntu-latest
     name: Build and push ${{ matrix.php-versions }} Docker image
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -30,13 +30,13 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
-      - name: Build and push
+      - name: Build only
         uses: docker/build-push-action@v2
         with:
           context: .
           push: false
           tags: |
-            pantheonpublic/build-tools-ci:8.x-php${{ matrix.php-versions }}
-            quay.io/pantheon-public/build-tools-ci:8.x-php${{ matrix.php-versions }}
+            pantheonpublic/build-tools-ci:9.x-php${{ matrix.php-versions }}
+            quay.io/pantheon-public/build-tools-ci:9.x-php${{ matrix.php-versions }}
           build-args: |
             PHPVERSION=${{ matrix.php-versions }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PHPVERSION
+ARG PHPVERSION=8.4
 
 # Use an official Python runtime as a parent image
 FROM cimg/php:${PHPVERSION}-browsers
@@ -38,23 +38,15 @@ RUN pecl config-set php_ini /usr/local/etc/php/php.ini && \
 
 ADD patches/641.diff /tmp/641.diff
 
-RUN pecl download imagick && \
-    tar -xvf imagick-*.tgz && \
-    rm imagick-*.tgz && \
-    cd imagick-* && \
-    git apply < /tmp/641.diff && \
-    phpize && \
-    ./configure && \
-    make && \
-    make install && \
-    cd .. && \
-    rm -rf imagick-*
-RUN docker-php-ext-enable imagick
+RUN apt-get install -y \
+    libmagickwand-dev --no-install-recommends \
+    && pecl install imagick \
+    && docker-php-ext-enable imagick
 
 RUN pecl install pcov
 RUN docker-php-ext-enable pcov
 
-RUN if [ "$PHPVERSION" = "7.4" ]; then pecl install xdebug-3.1.6; else pecl install xdebug; fi
+RUN pecl install xdebug
 RUN docker-php-ext-enable xdebug
 
 # Set the memory limit to unlimited for expensive Composer interactions
@@ -97,32 +89,19 @@ USER tester
 RUN git config --global --add safe.directory '*'
 
 # Install terminus
-RUN curl -L https://github.com/pantheon-systems/terminus/releases/download/3.4.0/terminus.phar -o /usr/local/bin/terminus && \
+RUN curl -L https://github.com/pantheon-systems/terminus/releases/download/4.0.0/terminus.phar -o /usr/local/bin/terminus && \
     chmod +x /usr/local/bin/terminus
 RUN terminus self:update
 
-# Install CLU
-RUN mkdir -p /usr/local/share/clu
-RUN /usr/bin/env COMPOSER_BIN_DIR=/usr/local/bin composer -n --working-dir=/usr/local/share/clu require danielbachhuber/composer-lock-updater:^0.8.2
-
-# Install Drush
-RUN mkdir -p /usr/local/share/drush
-RUN /usr/bin/env composer -n --working-dir=/usr/local/share/drush require drush/drush "^10"
-RUN ln -fs /usr/local/share/drush/vendor/drush/drush/drush /usr/local/bin/drush
-RUN chmod +x /usr/local/bin/drush
-
 # Add a collection of useful Terminus plugins
 RUN terminus self:plugin:add terminus-build-tools-plugin
-RUN terminus self:plugin:add terminus-clu-plugin
-RUN terminus self:plugin:add terminus-secrets-plugin
+RUN terminus self:plugin:add terminus-secrets-manager-plugin
 RUN terminus self:plugin:add terminus-rsync-plugin
-RUN terminus self:plugin:add terminus-quicksilver-plugin
 RUN terminus self:plugin:add terminus-composer-plugin
-RUN terminus self:plugin:add terminus-drupal-console-plugin
 RUN terminus self:plugin:add terminus-mass-update
 RUN terminus self:plugin:add terminus-site-clone-plugin
 
-ENV TERMINUS_PLUGINS_DIR=/home/tester/.terminus/plugins-3.x
+ENV TERMINUS_PLUGINS_DIR=/home/tester/.terminus/plugins-4.x
 ENV TERMINUS_DEPENDENCIES_BASE_DIR=/home/tester/.terminus/terminus-dependencies
 
 # Add phpcs for use in checking code style

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,14 @@ RUN curl -L https://github.com/pantheon-systems/terminus/releases/download/4.0.0
     chmod +x /usr/local/bin/terminus
 RUN terminus self:update
 
+# Install Drush.
+# It is recommended that you configure the PATH in your CI to include `vendor/bin` earlier
+# than `/usr/local/bin`. This will ensure that the site-local Drush is called first, and
+# the old Drush 10 global install (provided here for b/c) is not used.
+RUN mkdir -p /usr/local/share/drush
+RUN /usr/bin/env composer -n --working-dir=/usr/local/share/drush require drush/drush "^10"
+RUN ln -fs /usr/local/share/drush/vendor/drush/drush/drush /usr/local/bin/drush
+
 # Add a collection of useful Terminus plugins
 RUN terminus self:plugin:add terminus-build-tools-plugin
 RUN terminus self:plugin:add terminus-secrets-manager-plugin

--- a/README.md
+++ b/README.md
@@ -15,12 +15,9 @@ This is the source Dockerfile for the [pantheon-public/build-tools-ci](https://q
   - [Terminus Build Tools Plugin](https://github.com/pantheon-systems/terminus-build-tools-plugin)
   - [Terminus Secrets Plugin](https://github.com/pantheon-systems/terminus-secrets-plugin)
   - [Terminus Rsync Plugin](https://github.com/pantheon-systems/terminus-rsync-plugin)
-  - [Terminus Quicksilver Plugin](https://github.com/pantheon-systems/terminus-quicksilver-plugin)
   - [Terminus Composer Plugin](https://github.com/pantheon-systems/terminus-composer-plugin)
-  - [Terminus Drupal Console Plugin](https://github.com/pantheon-systems/terminus-drupal-console-plugin)
   - [Terminus Mass Update Plugin](https://github.com/pantheon-systems/terminus-mass-update)
-  - [Terminus Aliases Plugin](https://github.com/pantheon-systems/terminus-aliases-plugin)
-  - [Terminus CLU Plugin](https://github.com/pantheon-systems/terminus-clu-plugin)
+  - [Terminus Site Clone Plugin](https://github.com/pantheon-systems/terminus-site-clone-plugin)
 - Test tools
   - headless chrome
   - phpunit
@@ -33,48 +30,30 @@ This is the source Dockerfile for the [pantheon-public/build-tools-ci](https://q
 
 ## Branches
 
+- 9.x: Terminus 4. Produces 9.x-php8.4, 9.x-php8.3 and 9.x-php-8.4
 - 8.x: Use a CircleCI base image with Node JS, composer 2 and Terminus 3. Produces 8.x-php7.4, 8.x-php8.0, 8.x-php8.1, 8.x-php8.2 and 8.x-php8.3 image tags.
-- 7.x: Use a CircleCI base image with Node JS and composer 2. Produces 7.x-php7.3, 7.x-php7.4 and 7.x-php8.0 image tags.
-- 6.x: Use a CircleCI base image with Node JS (No longer maintained)
-- 5.x: Don't create multidevs when commits are made to the default branch, instead working directly on the dev environment (No longer maintained)
-- 4.x: Terminus 2.x and Build Tools 2.x (No longer maintained)
-- 3.x: Deprecated: Terminus 1 with Build Tools 2.0.0-beta2 (No longer maintained)
-- 2.x: Terminus 1.x and Build Tools 1.x (No longer maintained)
-- 1.x: Deprecated (No longer maintained)
 
-## 8.x Docker images
+Branches 7.x and lower are deprecated and unsupported.
+
+## 9.x Docker images
 
 ### Building the image
 
 From project root:
 
 ```
-# PHPVERSION could be 7.4, 8.0, 8.1, 8.2 or 8.3.
-PHPVERSION=7.4
-docker build --build-arg PHPVERSION=$PHPVERSION -t quay.io/pantheon-public/build-tools-ci:8.x-php${PHPVERSION} .
-```
-
-## 7.x Docker images
-
-### Building the image
-
-From project root:
-
-```
-# PHPVERSION could be 7.3, 7.4 or 8.0.
-PHPVERSION=7.4
-docker build --build-arg PHPVERSION=$PHPVERSION -t quay.io/pantheon-public/build-tools-ci:7.x-php${PHPVERSION} .
+# PHPVERSION could be 8.2, 8.3 or 8.4.
+PHPVERSION=8.4
+docker build --build-arg PHPVERSION=$PHPVERSION -t quay.io/pantheon-public/build-tools-ci:9.x-php${PHPVERSION} .
 ```
 
 ### Using the image
 
 #### Image name and tag
 
-- quay.io/pantheon-public/build-tools-ci:8.x-php7.4
-- quay.io/pantheon-public/build-tools-ci:8.x-php8.0
-- quay.io/pantheon-public/build-tools-ci:8.x-php8.1
-- quay.io/pantheon-public/build-tools-ci:8.x-php8.2
-- quay.io/pantheon-public/build-tools-ci:8.x-php8.3
+- quay.io/pantheon-public/build-tools-ci:9.x-php8.2
+- quay.io/pantheon-public/build-tools-ci:9.x-php8.3
+- quay.io/pantheon-public/build-tools-ci:9.x-php8.4
 
 #### Usage example
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is the source Dockerfile for the [pantheon-public/build-tools-ci](https://q
 - [Terminus](https://github.com/pantheon-systems/terminus)
 - Terminus plugins
   - [Terminus Build Tools Plugin](https://github.com/pantheon-systems/terminus-build-tools-plugin)
-  - [Terminus Secrets Plugin](https://github.com/pantheon-systems/terminus-secrets-plugin)
+  - [Terminus Secrets Manager Plugin](https://github.com/pantheon-systems/terminus-secrets-manager-plugin)
   - [Terminus Rsync Plugin](https://github.com/pantheon-systems/terminus-rsync-plugin)
   - [Terminus Composer Plugin](https://github.com/pantheon-systems/terminus-composer-plugin)
   - [Terminus Mass Update Plugin](https://github.com/pantheon-systems/terminus-mass-update)


### PR DESCRIPTION
- Upgrades to Terminus 4
- Adds PHP 8.4 image
- Includes Terminus Secrets Manager plugin in place of Terminus Secrets plugin
- Removes unsupported Terminus plugins and PHP versions
